### PR TITLE
Actualización nombre

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
-        android:label="frontend"
+        android:label="PressureCare"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Frontend</string>
+	<string>PressureCare</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/frontend/lib/controls/backendService/facade_services.dart
+++ b/frontend/lib/controls/backendService/facade_services.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import 'package:frontend/controls/backendService/generic_answer.dart';
-import 'package:frontend/controls/backendService/model/register.dart';
-import 'package:frontend/controls/conexion.dart';
-import 'package:frontend/controls/backendService/model/login.dart';
+import 'package:PressureCare/controls/backendService/generic_answer.dart';
+import 'package:PressureCare/controls/backendService/model/register.dart';
+import 'package:PressureCare/controls/conexion.dart';
+import 'package:PressureCare/controls/backendService/model/login.dart';
 import 'package:http/http.dart' as http;
 
 class FacadeServices {

--- a/frontend/lib/controls/backendService/model/login.dart
+++ b/frontend/lib/controls/backendService/model/login.dart
@@ -1,4 +1,4 @@
-import 'package:frontend/controls/backendService/generic_answer.dart';
+import 'package:PressureCare/controls/backendService/generic_answer.dart';
 
 class Login extends GenericAnswer {
   Login({required super.msg, required super.code, required super.data});

--- a/frontend/lib/controls/backendService/model/register.dart
+++ b/frontend/lib/controls/backendService/model/register.dart
@@ -1,4 +1,4 @@
-import 'package:frontend/controls/backendService/generic_answer.dart';
+import 'package:PressureCare/controls/backendService/generic_answer.dart';
 
 class Register extends GenericAnswer {
   Register({required super.msg, required super.code, required super.data});

--- a/frontend/lib/controls/conexion.dart
+++ b/frontend/lib/controls/conexion.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'package:http/http.dart' as http;
-import 'package:frontend/controls/util/util.dart';
-import 'package:frontend/controls/backendService/generic_answer.dart';
+import 'package:PressureCare/controls/util/util.dart';
+import 'package:PressureCare/controls/backendService/generic_answer.dart';
 
 class Conexion {
   static const String URL = 'https://preasurecare.onrender.com/pressure/';

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/views/exception/page404.dart';
-import 'package:frontend/views/patient/presure_register_view.dart';
-import 'package:frontend/views/login_view.dart';
-import 'package:frontend/views/register_view.dart';
+import 'package:PressureCare/views/exception/page404.dart';
+import 'package:PressureCare/views/patient/presure_register_view.dart';
+import 'package:PressureCare/views/login_view.dart';
+import 'package:PressureCare/views/register_view.dart';
 
 void main() {
   runApp(const MyApp());

--- a/frontend/lib/services/login_service.dart
+++ b/frontend/lib/services/login_service.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'dart:developer';
 
-import 'package:frontend/controls/backendService/facade_services.dart';
-import 'package:frontend/controls/util/util.dart';
-import 'package:frontend/services/navigation_service.dart';
-import 'package:frontend/widgets/toast/error.dart';
-import 'package:frontend/widgets/toast/informative.dart';
+import 'package:PressureCare/controls/backendService/facade_services.dart';
+import 'package:PressureCare/controls/util/util.dart';
+import 'package:PressureCare/services/navigation_service.dart';
+import 'package:PressureCare/widgets/toast/error.dart';
+import 'package:PressureCare/widgets/toast/informative.dart';
 
 class LoginService {
   static Future<void> login({

--- a/frontend/lib/services/navigation_service.dart
+++ b/frontend/lib/services/navigation_service.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/views/patient/presure_register_view.dart';
-import 'package:frontend/views/doctor/patient_list_view.dart';
-import 'package:frontend/views/exception/page404.dart';
-import 'package:frontend/services/auth_service.dart';
+import 'package:PressureCare/views/patient/presure_register_view.dart';
+import 'package:PressureCare/views/doctor/patient_list_view.dart';
+import 'package:PressureCare/views/exception/page404.dart';
+import 'package:PressureCare/services/auth_service.dart';
 
 class NavigationService {
   static const Map<String, Widget> roleViews = {

--- a/frontend/lib/services/register_service.dart
+++ b/frontend/lib/services/register_service.dart
@@ -1,9 +1,9 @@
 import 'dart:developer';
 import 'package:flutter/material.dart';
-import 'package:frontend/controls/backendService/facade_services.dart';
-import 'package:frontend/services/login_service.dart';
-import 'package:frontend/widgets/toast/error.dart';
-import 'package:frontend/widgets/toast/informative.dart';
+import 'package:PressureCare/controls/backendService/facade_services.dart';
+import 'package:PressureCare/services/login_service.dart';
+import 'package:PressureCare/widgets/toast/error.dart';
+import 'package:PressureCare/widgets/toast/informative.dart';
 
 class RegisterService {
   static Future<void> registerUser({

--- a/frontend/lib/views/doctor/patient_list_view.dart
+++ b/frontend/lib/views/doctor/patient_list_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/controls/backendService/facade_services.dart';
-import 'package:frontend/views/doctor/patient_pressure_view.dart';
+import 'package:PressureCare/controls/backendService/facade_services.dart';
+import 'package:PressureCare/views/doctor/patient_pressure_view.dart';
 
 class PatientListView extends StatefulWidget {
   const PatientListView({super.key});

--- a/frontend/lib/views/doctor/patient_pressure_view.dart
+++ b/frontend/lib/views/doctor/patient_pressure_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/controls/backendService/facade_services.dart';
-import 'package:frontend/widgets/home/pressure_history_table.dart';
-import 'package:frontend/widgets/toast/error.dart';
+import 'package:PressureCare/controls/backendService/facade_services.dart';
+import 'package:PressureCare/widgets/home/pressure_history_table.dart';
+import 'package:PressureCare/widgets/toast/error.dart';
 
 class PatientHistoryView extends StatefulWidget {
   final String patientId;

--- a/frontend/lib/views/login_view.dart
+++ b/frontend/lib/views/login_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:frontend/services/login_service.dart';
-import 'package:frontend/widgets/buttons/button.dart';
+import 'package:PressureCare/services/login_service.dart';
+import 'package:PressureCare/widgets/buttons/button.dart';
 import 'package:validators/validators.dart';
 
 class LoginView extends StatefulWidget {

--- a/frontend/lib/views/patient/presure_register_view.dart
+++ b/frontend/lib/views/patient/presure_register_view.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/controls/util/util.dart';
-import 'package:frontend/widgets/home/last_pressure_card.dart';
-import 'package:frontend/widgets/home/medication_dialog.dart';
-import 'package:frontend/widgets/home/pressure_form.dart';
-import 'package:frontend/widgets/home/pressure_history_table.dart';
-import 'package:frontend/widgets/toast/error.dart';
-import 'package:frontend/widgets/toast/confirm.dart';
-import 'package:frontend/controls/backendService/facade_services.dart';
-import 'package:frontend/widgets/toast/informative.dart';
+import 'package:PressureCare/controls/util/util.dart';
+import 'package:PressureCare/widgets/home/last_pressure_card.dart';
+import 'package:PressureCare/widgets/home/medication_dialog.dart';
+import 'package:PressureCare/widgets/home/pressure_form.dart';
+import 'package:PressureCare/widgets/home/pressure_history_table.dart';
+import 'package:PressureCare/widgets/toast/error.dart';
+import 'package:PressureCare/widgets/toast/confirm.dart';
+import 'package:PressureCare/controls/backendService/facade_services.dart';
+import 'package:PressureCare/widgets/toast/informative.dart';
 import 'package:intl/intl.dart';
 
 class PressureRegisterView extends StatefulWidget {

--- a/frontend/lib/views/register_view.dart
+++ b/frontend/lib/views/register_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:frontend/services/register_service.dart';
-import 'package:frontend/widgets/buttons/button.dart';
+import 'package:PressureCare/services/register_service.dart';
+import 'package:PressureCare/widgets/buttons/button.dart';
 import 'package:validators/validators.dart';
 
 class RegisterView extends StatefulWidget {

--- a/frontend/lib/widgets/home/pressure_form.dart
+++ b/frontend/lib/widgets/home/pressure_form.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/widgets/buttons/button.dart';
+import 'package:PressureCare/widgets/buttons/button.dart';
 
 class PressureForm extends StatelessWidget {
   final GlobalKey<FormState> formKey;

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,5 +1,5 @@
-name: frontend
-description: "A new Flutter project."
+name: PressureCare
+description: "Aplicación móvil que permite llevar un control de la presión arterial de cada paciente, además de brindar la dosificación necesaria para cada tipo."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:frontend/main.dart';
+import 'package:PressureCare/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
Renombrar el paquete de 'frontend' a 'PressureCare' en todo el proyecto para reflejar el nuevo nombre de la aplicación.